### PR TITLE
Bump Terraform version in `README.md` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ GitHub Action for setting up a workflow to execute [`terraform apply`](https://w
 ```yaml
 jobs:
   main:
-    name: Deployment
+    name: Deploy
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Terraform
         uses: flipgroup/action-terraform-apply@main
         with:
-          version: 1.0.0
+          version: 1.1.5
           workspace: prod
 
       # -- as an example --


### PR DESCRIPTION
Moving along the workflow usage example to latest stable Terraform: https://github.com/hashicorp/terraform/releases/tag/v1.1.5