### PR TITLE
Add SSH private key install options to allow easier use of Terraform modules in private GitHub repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Action Terraform apply
 
-GitHub Action for setting up a workflow to execute [`terraform apply`](https://developer.hashicorp.com/terraform/cli/commands/apply) operations in CI/CD pipelines for a given workspace.
+GitHub Action that will configure a workflow for executing [`terraform apply`](https://developer.hashicorp.com/terraform/cli/commands/apply) operations in CI/CD pipelines for a given workspace.
 
 ## Usage
 
@@ -18,11 +18,33 @@ jobs:
           version: 1.7.5
           workspace: prod
 
-      # -- as an example --
+      # workflow now configured for use with terraform
 
       - name: Terraform apply
         run: |
           cd ops/my-terraform-configuration
           terraform init
           terraform apply
+```
+
+Optionally, the Action can configure the following properties, allowing use of a private GitHub repository as a [Module source](https://developer.hashicorp.com/terraform/language/modules/sources#github) for Terraform configurations:
+
+- Start `ssh-agent` and add a given SSH private key.
+- Configure `git` with a HTTPS -> SSH clone target [`url.<base>.insteadOf`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf) rewrite.
+
+```yaml
+jobs:
+  main:
+    name: Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Setup Terraform
+        uses: flipgroup/action-terraform-apply@main
+        with:
+          version: 1.7.5
+          workspace: prod
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          github-module-repository: owner/module-repository
 ```

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,12 @@ inputs:
   workspace:
     description: Terraform workspace name.
     required: true
+  ssh-private-key:
+    description: Optional SSH private key, added to ssh-agent.
+    default:
+  github-module-repository:
+    description: Optional GitHub Terraform module repository as owner/name, added as HTTPS -> SSH clone target.
+    default:
 
 runs:
   using: composite
@@ -22,4 +28,21 @@ runs:
         echo "TF_IN_AUTOMATION=true" >>"$GITHUB_ENV"
         echo "TF_INPUT=false" >>"$GITHUB_ENV"
         echo "TF_WORKSPACE=${{ inputs.workspace }}" >>"$GITHUB_ENV"
+      shell: bash
+    - name: Add SSH private key to ssh-agent
+      if: inputs.ssh-private-key != ''
+      env:
+        # note: using env var to avoid masked key output into workflow run log
+        SSH_PRIVATE_KEY: ${{ inputs.ssh-private-key }}
+      run: |
+        eval $(ssh-agent -s)
+        echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >>"$GITHUB_ENV"
+        echo "$SSH_PRIVATE_KEY" | ssh-add -
+      shell: bash
+    - name: Set GitHub Terraform module repository
+      if: inputs.github-module-repository != ''
+      run: |
+        git config --global \
+          url."ssh://git@github.com/${{ inputs.github-module-repository }}".insteadOf \
+          "https://github.com/${{ inputs.github-module-repository }}"
       shell: bash


### PR DESCRIPTION
This change adds the following two new action inputs:

- `ssh-private-key`
- `github-module-repository`

This will install the given SSH private key into a started `ssh-agent` that will live for the remainder of the GitHub Actions workflow and setup a `git` HTTPS -> SSH `insteadOf` configuration directive.

With this in place, using Terraform in workflows with modules held in a private GitHub repository can be used. It is expected the SSH public key is added as a read-only [Deploy Key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys) within the Terraform module GitHub repository.

E.g.

```hcl
module "my_module" {
  source = "github.com/owner/module-repo//my-cool-module?depth=1&ref=main"
  name   = "apples-oranges"
}
```
