### PR TITLE
GitHub Actions bump Node.js `v24` releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,13 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v6
       - name: Setup Terraform
         uses: flipgroup/action-terraform-apply@main
         with:
           version: 1.12.2
           workspace: prod
 
-      # workflow now configured for use with terraform
+      # workflow now configured for use with Terraform
 
       - name: Terraform apply
         run: |
@@ -27,7 +25,7 @@ jobs:
           terraform apply
 ```
 
-Optionally, the Action can configure the following properties, allowing use of a private GitHub repository as a [Module source](https://developer.hashicorp.com/terraform/language/modules/sources#github) for Terraform configurations:
+Optionally, the Action can configure the following properties, allowing use of a private GitHub repository as a [Module source](https://developer.hashicorp.com/terraform/language/block/module#github-repository) for Terraform configurations:
 
 - Start `ssh-agent` and add a given SSH private key.
 - Configure `git` with a HTTPS -> SSH clone target [`url.<base>.insteadOf`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf) rewrite.
@@ -38,8 +36,6 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v6
       - name: Setup Terraform
         uses: flipgroup/action-terraform-apply@main
         with:

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3
+      uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # @v4.0.1
       with:
         terraform_version: ${{ inputs.version }}
         terraform_wrapper: false


### PR DESCRIPTION
Applies the following GitHub Action workflow changes:

- Implement the use of GitHub Actions compatible with Node.js `v24`.
- Swap out the use of version tags for external actions to full SHA-1 commits to defeat action tainting / supply chain attacks.
